### PR TITLE
Using helper method for outposts

### DIFF
--- a/ts-source/src/repository/Room.ts
+++ b/ts-source/src/repository/Room.ts
@@ -96,7 +96,8 @@ export function getAllPoachroomsInAllRooms(rooms: Room[]): string[] {
 
 export function getNumberOfSourcesMined(room: Room): number {
     let sourceCount = (room.find(FIND_SOURCES) as Source[]).length;
-    for (let outpost of room.memory.outposts) {
+
+    for (let outpost of getAllOutposts(room)) {
         if (IntelLib.hasIntel(outpost)) {
             sourceCount += IntelLib.sourceIds(outpost).length;
         }


### PR DESCRIPTION
Essentially, when you respawn, the outposts property doesn't get set on the room. This may not be the correct fix, but I don't know the code base well enough to tell. The other option is to set the outposts property on room creation, but I figured this wasn't correct because the addOutpost command sets it if it doesn't already exist.